### PR TITLE
-- Fix image reconstruction display by decoupling image recon metrics and image reconstruction. Image metrics do NOT depend on data but does depend on forward model sensitivity matrix. Metrics should be moved to forward model.

### DIFF
--- a/AtlasViewerGUI.m
+++ b/AtlasViewerGUI.m
@@ -2763,12 +2763,6 @@ axesv       = atlasViewer.axesv;
 set(imgrecon.handles.popupmenuImageDisplay,'value',imgrecon.menuoffset+1);
 set(handles.editColormapThreshold,'string',sprintf('%0.2g %0.2g',imgrecon.cmThreshold(imgrecon.menuoffset+1,1), ...
                                                                  imgrecon.cmThreshold(imgrecon.menuoffset+1,2)));
-
-imgrecon = inputParamsImgRecon(imgrecon);
-if isempty(imgrecon)
-    return;
-end
-
 imgrecon = genImgReconMetrics(imgrecon, fwmodel, dirnameSubj);
 
 % Turn off image recon display

--- a/ImgRecon/ImageRecon.m
+++ b/ImgRecon/ImageRecon.m
@@ -251,7 +251,12 @@ if value2 == 1 & ndims(Adot_scalp) < 3
 end
 
 %%%% Get probe data 
-SD   = convertProbe2SD(probe);
+SD = convertProbe2SD(probe);
+SD2 = dataTree.currElem.GetMeasList();
+SD2.Lambda = dataTree.currElem.GetWls();
+SD.Lambda = SD2.Lambda;
+SD.MeasList = SD2.MeasList;
+SD.MeasListAct = SD2.MeasListAct;
 
 % Get fnirs time course data
 dc   = dataTree.currElem.GetDcAvg();
@@ -434,6 +439,7 @@ saveImgRecon(imgrecon);
 atlasViewer.imgrecon = imgrecon;
 
 
+
 % ---------------------------------------------------------------------------------
 function plotHb_Callback(~, ~, handles)
 % This function executes on button press in plotHb.
@@ -525,7 +531,6 @@ hbconc = showHbConcDisplay(hbconc, axesv(1).handles.axesSurfDisplay, 'off', 'off
 
 % Turn resolution on and localization error display off
 imgrecon = showImgReconDisplay(imgrecon, axesv(1).handles.axesSurfDisplay, 'off', 'off', 'on', 'off');
-
 
 atlasViewer.fwmodel = fwmodel;
 atlasViewer.imgrecon = imgrecon;

--- a/ImgRecon/showImgReconDisplay.m
+++ b/ImgRecon/showImgReconDisplay.m
@@ -1,8 +1,5 @@
 function imgrecon = showImgReconDisplay(imgrecon, hAxes, valLocErr, valRes, valHbO, valHbR)
 
-if isempty(imgrecon.handles.hLocalizationError)
-    return;
-end
 if isempty(hAxes)
     hAxes=gca;
 end
@@ -17,7 +14,6 @@ if strcmp(valHbO, 'on') | strcmp(valHbR, 'on')
 else
     valImgRecon='off';
 end
-
 
 if strcmp(valMetrics,'off') & strcmp(valImgRecon,'off')
     imgrecon = setImgReconColormap(imgrecon, []);

--- a/Utils/getVernum.m
+++ b/Utils/getVernum.m
@@ -20,7 +20,7 @@ function [vrnnum] = getVernum_AtlasViewerGUI()
 
 vrnnum{1} = '2';   % Major version #
 vrnnum{2} = '15';  % Major sub-version #
-vrnnum{3} = '11';   % Minor version #
+vrnnum{3} = '12';   % Minor version #
 vrnnum{4} = '0';   % Minor sub-version # or patch #: 'p1', 'p2', etc
 
 


### PR DESCRIPTION
-- Fix image reconstruction display by decoupling image recon metrics and image reconstruction. Image metrics do NOT depend on data but does depend on forward model sensitivity matrix. Metrics should be moved to forward model.