### PR TITLE
[Fix] Fixes in mcx config and brain-and-scalp recon

### DIFF
--- a/ForwardModel/runMCXlab.m
+++ b/ForwardModel/runMCXlab.m
@@ -249,11 +249,12 @@ for iWav = 1:num_wavelengths
         cfg.isnormalized = 1;
         cfg.outputtype = 'fluence';
         
-        cfg.prop=[         0         0    1.0000    1.0000 % background/air
-            tiss_prop(1).absorption(iWav) tiss_prop(1).scattering(iWav) tiss_prop(1).anisotropy(1) tiss_prop(1).refraction(1)
-            tiss_prop(2).absorption(iWav) tiss_prop(2).scattering(iWav) tiss_prop(2).anisotropy(1) tiss_prop(2).refraction(1)
-            tiss_prop(3).absorption(iWav) tiss_prop(3).scattering(iWav) tiss_prop(3).anisotropy(1) tiss_prop(3).refraction(1)
-            tiss_prop(4).absorption(iWav) tiss_prop(4).scattering(iWav) tiss_prop(4).anisotropy(1) tiss_prop(4).refraction(1) ];
+        cfg.prop=[         0         0    1.0000    1.0000 ]; % background/air
+        for i = 1:length(tiss_prop)
+            cfg.prop = [cfg.prop; ...
+                tiss_prop(i).absorption(iWav) tiss_prop(i).scattering(iWav) tiss_prop(i).anisotropy(1) tiss_prop(i).refraction(1)]
+
+        end
         
         cfg.seed=floor(rand()*10e+7);
         cfg.nphoton=num_phot;

--- a/ImgRecon/ImageRecon.m
+++ b/ImgRecon/ImageRecon.m
@@ -283,13 +283,10 @@ if value1 == 1 % brain only reconstruction after short separation regression
     end
     
 elseif value2 == 1 % brain and scalp reconstruction without short separation regression (Zhan2012)
-    
-    Adot = Adot(activeChIdxs,:,:);
-    Adot = Adot(longSepChLst,:,:);
-    
-    Adot_scalp = Adot_scalp(activeChIdxs,:,:);
-    Adot_scalp = Adot_scalp(longSepChLst,:,:);
-    
+
+    Adot = Adot(activeChLst_SDpairs,:,:);
+    Adot_scalp = Adot_scalp(activeChLst_SDpairs,:,:);
+
     % get alpha and beta for regularization
     alpha = str2num(get(handles.alpha_brain_scalp,'String')); %#ok<*ST2NM>
     beta = str2num(get(handles.beta_brain_scalp,'String'));


### PR DESCRIPTION
Hi,

Here are fixes for two small issues that I met while running image recon on custom MRI:

- cfg.prop accepts solely 4 tissue types, which is not true in every case
- activeChIdxs stoped existing several commits ago and was not removed from brain-and-scalp recon